### PR TITLE
Guard cafe/graphs.tcl cleanup with catch (read-only package safe)

### DIFF
--- a/code/procs_vars.tcl
+++ b/code/procs_vars.tcl
@@ -35,7 +35,9 @@ set ::user(button_radius) 30
 set ::settings(scale_stop_at_half_shot) 0
 
 if {[file exists [skin_directory]/pages/cafe/graphs.tcl]} {
-    file delete -force [skin_directory]/pages/cafe/graphs.tcl
+    # runs at skin load; catch so a read-only package (iOS / in-place run) can't
+    # crash at boot trying to delete from the bundle
+    catch { file delete -force [skin_directory]/pages/cafe/graphs.tcl }
 }
 if {$::skin(colour_theme_folder) == "default"} {
     set basedir [skin_directory]/colour_themes/default.txt


### PR DESCRIPTION
### What
Wrap the skin-load `pages/cafe/graphs.tcl` cleanup in `catch`.

### Why
On a read-only install — iOS, or any in-place run from an immutable/notarized macOS bundle — the stale `graphs.tcl` ships *inside* the bundle and can't be deleted, so the bare `file delete -force` throws during skin load and DSx2 fails to boot (grey screen). The existing `[file exists]` guard only handles the *absent* case; this handles *present-but-undeletable*.

### Risk
Minimal — on a normal writable install the delete still happens; `catch` only swallows the failure path. Self-contained, no other changes or dependencies.
