### PR TITLE
Writable per-skin data dir for settings/cache/history (read-only package safe)

### DIFF
--- a/code/procs_vars.tcl
+++ b/code/procs_vars.tcl
@@ -232,8 +232,8 @@ proc skin_history_2 {} {
 }
 
 proc create_settings_dir {} {
-    if {[file exists [skin_directory]/settings] != 1} {
-        set path [skin_directory]/settings
+    if {[file exists [dsx2_settings_dir]] != 1} {
+        set path [dsx2_settings_dir]
         file mkdir $path
         file attributes $path
     }
@@ -4141,7 +4141,7 @@ proc save_graph_cache { args } {
         }
     }
 
-    write_file "[skin_directory]/settings/graph_cache.tdb" $graph_cache_data
+    write_file "[dsx2_settings_dir]/graph_cache.tdb" $graph_cache_data
 }
 
 proc restore_cache_graphs {} {
@@ -4192,7 +4192,7 @@ proc cache_date_time_format { time } {
 
 
 proc load_graph_cache {} {
-    array set ::graph_cache [encoding convertfrom utf-8 [read_binary_file "[skin_directory]/settings/graph_cache.tdb"]]
+    array set ::graph_cache [encoding convertfrom utf-8 [read_binary_file "[dsx2_settings_dir]/graph_cache.tdb"]]
 }
 
 proc skin_load_fav { args } {

--- a/code/save_and_load.tcl
+++ b/code/save_and_load.tcl
@@ -73,7 +73,7 @@ proc skin_save {key} {
             set v $item($k)
             append data [subst {[list $k] [list $v]\n}]
         }
-        write_file [skin_directory]/settings/${key}_settings.txt $data
+        write_file [dsx2_settings_dir]/${key}_settings.txt $data
     }
     if {$key == "skin_graphs"} {
         upvar ::skin_graphs item
@@ -82,7 +82,7 @@ proc skin_save {key} {
             set v $item($k)
             append data [subst {[list $k] [list $v]\n}]
         }
-        write_file [skin_directory]/settings/$key.txt $data
+        write_file [dsx2_settings_dir]/$key.txt $data
     }
     if {$key == "jug_s" || $key == "jug_m" || $key == "jug_l"} {
         set ::skin($key) [round_to_one_digits $::de1(scale_sensor_weight)]
@@ -128,7 +128,7 @@ proc skin_save {key} {
         }
         append data "}\n"
 
-        write_file [skin_directory]/settings/$key.txt $data
+        write_file [dsx2_settings_dir]/$key.txt $data
         update_de1_explanation_chart
         if {$::skin(theme) == "Damian"} {
             check_wf_steam_jug_auto_weight
@@ -144,7 +144,7 @@ proc skin_load {key} {
     if {$key == "none"} {
         return
     }
-    if {[file exists [skin_directory]/settings/$key.txt]} {
+    if {[file exists [dsx2_settings_dir]/$key.txt]} {
         set previous_profile_filename [ifexists ::settings(profile_filename)]
         set previous_workflow [ifexists ::skin(workflow)]
         set previous_beverage_type [ifexists ::settings(beverage_type)]
@@ -153,7 +153,7 @@ proc skin_load {key} {
             set ::skin(fav_key) $key
         }
         array unset -nocomplain fav_settings
-        array set fav_settings [encoding convertfrom utf-8 [read_binary_file "[skin_directory]/settings/$key.txt"]]
+        array set fav_settings [encoding convertfrom utf-8 [read_binary_file "[dsx2_settings_dir]/$key.txt"]]
         array set settings $fav_settings(app)
         set selected_profile_filename [ifexists settings(profile_filename)]
         set changing_profile [expr {$selected_profile_filename ne "" && $selected_profile_filename ne $previous_profile_filename}]

--- a/plugins/history_viewer.tcl
+++ b/plugins/history_viewer.tcl
@@ -339,7 +339,7 @@ set ::history_count 0
 
 proc history_list {{limit $::skin(history_sch_limit)}} {
     set result {}
-    set files [lsort -dictionary -decreasing [glob -nocomplain -tails -directory "[homedir]/history/" *.shot]]
+    set files [lsort -dictionary -decreasing [glob -nocomplain -tails -directory "[data_directory]/history/" *.shot]]
     set ::history_count [llength $files]
     if {$::history_count < $::skin(history_sch_limit)} {
         set ::skin(history_sch_limit) $::history_count
@@ -386,7 +386,7 @@ if {![info exist ::skin(history_position)]} {
 
 proc graph_number {} {
     if {$::history_count < 10} {
-        set files [lsort -dictionary -decreasing [glob -nocomplain -tails -directory "[homedir]/history/" *.shot]]
+        set files [lsort -dictionary -decreasing [glob -nocomplain -tails -directory "[data_directory]/history/" *.shot]]
         set ::history_count [llength $files]
         return [lrange {1 2 3 4 5 6 7 8 9 10} 0 [expr $::history_count - 1]]
     } else {
@@ -400,8 +400,8 @@ proc get_history_data {pos} {
         clear_history_graphs $graph
         set p [expr $pos + $graph - 1]
         set file_name [history_position $p]
-        if {[file exists "[homedir]/history/$file_name"]} {
-            array set ::selected_history_data [read_file "[homedir]/history/$file_name"]
+        if {[file exists "[data_directory]/history/$file_name"]} {
+            array set ::selected_history_data [read_file "[data_directory]/history/$file_name"]
         }
         foreach lg [history_graph_list] {
             $lg length 0

--- a/skin.tcl
+++ b/skin.tcl
@@ -7,20 +7,37 @@ if {[file exists "[skin_directory]/Damian.start"]} {
     source  [file join "[skin_directory]/" Damian.start]
 }
 proc check_MySaver_exists {} {
-    set dir "[homedir]/MySaver"
+    set dir "[data_directory]/MySaver"
     set file_list [glob -nocomplain "$dir/*"]
     if {[llength $file_list] != 0} {
-        set_de1_screen_saver_directory "[homedir]/MySaver"
+        set_de1_screen_saver_directory "[data_directory]/MySaver"
     }
 }
 check_MySaver_exists
 
-array set ::skin [encoding convertfrom utf-8 [read_binary_file "[skin_directory]/code/default_settings.txt"]]
-if {[file exists "[skin_directory]/settings/skin_settings.txt"] == 1} {
-    array set ::skin [encoding convertfrom utf-8 [read_binary_file "[skin_directory]/settings/skin_settings.txt"]]
+# DSx2 keeps its mutable settings in the writable per-skin data dir (so they
+# persist even when the skin ships in a read-only package), seeded once from the
+# skin's shipped settings/. Defined here, before the first settings read below.
+proc dsx2_settings_dir {} {
+    set d [skin_settings_directory DSx2]
+    if {![file exists "$d/.seeded"]} {
+        catch {
+            foreach f [glob -nocomplain "[skin_directory]/settings/*"] {
+                set dst "$d/[file tail $f]"
+                if {![file exists $dst]} { catch { file copy -- $f $dst } }
+            }
+            catch { close [open "$d/.seeded" w] }
+        }
+    }
+    return $d
 }
-if {[file exists "[skin_directory]/settings/skin_graphs.txt"] == 1} {
-    array set ::skin_graphs [encoding convertfrom utf-8 [read_binary_file "[skin_directory]/settings/skin_graphs.txt"]]
+
+array set ::skin [encoding convertfrom utf-8 [read_binary_file "[skin_directory]/code/default_settings.txt"]]
+if {[file exists "[dsx2_settings_dir]/skin_settings.txt"] == 1} {
+    array set ::skin [encoding convertfrom utf-8 [read_binary_file "[dsx2_settings_dir]/skin_settings.txt"]]
+}
+if {[file exists "[dsx2_settings_dir]/skin_graphs.txt"] == 1} {
+    array set ::skin_graphs [encoding convertfrom utf-8 [read_binary_file "[dsx2_settings_dir]/skin_graphs.txt"]]
 }
 
 proc D_join_files_in_dir {dir} {
@@ -40,8 +57,8 @@ D_join_files_in_dir pages/$::skin(theme)
 D_join_files_in_dir plugins
 D_join_files_in_dir manuals
 
-if {[file exists "[skin_directory]/settings/D_graphs.tdb"]} {
-    array set ::D_graphs [encoding convertfrom utf-8 [read_binary_file "[skin_directory]/settings/D_graphs.tdb"]]
+if {[file exists "[dsx2_settings_dir]/D_graphs.tdb"]} {
+    array set ::D_graphs [encoding convertfrom utf-8 [read_binary_file "[dsx2_settings_dir]/D_graphs.tdb"]]
 }
 .can configure -bg $::skin_background_colour
 


### PR DESCRIPTION
### What
Route DSx2's mutable settings / graph cache / saver / history paths to a writable per-skin data dir, so the skin works when it ships inside a **read-only package** (iOS, or an in-place run from an immutable/notarized macOS bundle).

- New `proc dsx2_settings_dir` → `[skin_settings_directory DSx2]`, seeded once from the skin's shipped `settings/` (so existing writable installs migrate their saved settings/favourites automatically).
- `[skin_directory]/settings/*` → `[dsx2_settings_dir]/*` — `skin_settings.txt`, `skin_graphs.txt`, `D_graphs.tdb`, `graph_cache.tdb`, the per-favourite files in `skin_save`/`skin_load`, and `skin_history_2`.
- `[homedir]/MySaver` and `[homedir]/history/` → `[data_directory]/…`.

### ⚠️ Dependency — please don't merge before de1app core ships these
This relies on two de1app **core** procs that may not be in your current de1app yet:

- `data_directory` — the writable data root (equals `homedir` on desktop; a separate writable dir on iOS / read-only builds).
- `skin_settings_directory <skin>` — a per-skin writable settings dir under `data_directory`.

These are going into de1app core. On a normal desktop build `data_directory == homedir`, so behaviour is unchanged; the split only matters on read-only / iOS packaging. Happy to point you at the matching core change, or hold this until that de1app release lands.

### Risk
No behavioural change on a writable desktop install — the paths resolve to the same place. The seeding is one-time, guarded by a `.seeded` marker.
