### PR TITLE
First-draw page bounce for the cafe page (same fix as DSx_final_prep)

### DIFF
--- a/skin.tcl
+++ b/skin.tcl
@@ -51,3 +51,12 @@ set ::settings(disable_long_press) 0
 if {[file exists "[skin_directory]/Damian.end"]} {
     source  [file join "[skin_directory]/" Damian.end]
 }
+
+# Force a page bounce so the home page fully renders on first draw. DSx2 normally
+# finalizes the home page via skin_load_fav (fired on the DE1 Sleep->Idle state
+# change), but that is a no-op when no favorite is active -- e.g. a fresh data
+# dir -- which left the cafe page half-drawn (empty graphs, missing legend/icons)
+# until a manual page change. Bouncing through settings_1 forces the transition
+# that finalizes the draw. Mirrors DSx's DSx_final_prep fix.
+page_show settings_1
+after 50 { catch { page_show off } }


### PR DESCRIPTION
### What
Add a one-time page bounce at DSx2 skin load so the cafe (home) page fully finalizes on first draw.

### Why
DSx2 finalizes the home page via `skin_load_fav`, which fires on the DE1 `Sleep→Idle` state change. When no favorite is active that's a no-op, so the cafe page can come up half-drawn (empty graphs, missing legend/icons) until a manual page change finalizes it.

### Fix — the same one you already applied to DSx
This is the exact pattern you shipped in **DSx** (`DSx_final_prep`):

```tcl
page_show settings_1
after 50 page_show off
```

Bouncing through `settings_1` at skin load forces the transition that finalizes the draw. This PR applies that same DSx fix to DSx2's `skin.tcl`.

### Risk
Minimal — one extra page transition at startup, identical in spirit to DSx's `DSx_final_prep`.
